### PR TITLE
Added proper toString output and modified execute method

### DIFF
--- a/src/me/wheezygold/skLib/WIP/EffSetScoreSB.java
+++ b/src/me/wheezygold/skLib/WIP/EffSetScoreSB.java
@@ -35,13 +35,18 @@ public class EffSetScoreSB extends Effect {
 	@Override
 	public String toString(@Nullable Event arg0, boolean arg1) {
 		// TODO Auto-generated method stub
-		return null;
+		return "set score at " + slot.getSingle(arg0) + " of " + player.getSingle(arg0) + " score board to " + value.getSingle(arg0); 
 	}
 
 	@Override
 	protected void execute(Event evt) {
-		int slotnum = Integer.valueOf(slot.toString());
-		SbManager.setscoresb(player.getSingle(evt), slotnum, value.getSingle(evt));
+		if((slot.getSingle() == null) || (player.getSingle(evt) == null) || (value.getSingle(evt) == null)){
+			Skript.error("Must provide all values, refer to syntax.");
+			
+		}else{
+			int slotnum = Integer.valueOf(slot.toString());
+			SbManager.setscoresb(player.getSingle(evt), slotnum, value.getSingle(evt));
+		}
 		
 	}
 


### PR DESCRIPTION
You want to return something in the toString method for when a error happens, you basically just recreate your syntax and use the variables, so if they provide null for something it will show what they provided null for. So if they did `set score at 5 of player to ""` with nothing in the quotes it will error saying `set score at 5 of player to null` so you know what's wrong. Also you should be null checking in the execute method that way you can send out the error rather that it printing a nullpointer.